### PR TITLE
Change Println to Printf for Formatting

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 		}
 
 		ret, _ := fib_recurse(val)
-		fmt.Println("Fibonacci recursively for %d", val)
+		fmt.Printf("Fibonacci recursively for %d: %d", val, ret)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fmt.Sprintf("%d\n", ret)))
 	})


### PR DESCRIPTION
Fixed typo where the old code used Println, which would print out a "%d" rather than the fibonacci number. Now uses Printf and also prints the calculated number.